### PR TITLE
writing prettified quickFix.lock file instead of minified.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,7 +95,10 @@ module.exports = {
 
     //Create and save to __quickfix__/quickfix.lock
     const path = root + "/__quickfix__";
-    jsonfile.writeFileSync(path + "/quickfix.lock", changes);
+    jsonfile.writeFileSync(path + "/quickfix.lock", changes, {
+      spaces: '\t',
+      replacer: null
+    });
   },
   deleteCache: function() {
     console.log("> Cleaning cache.");


### PR DESCRIPTION
to log prettified json using JSON.stringify
`JSON.stringify({ obj: 'this is a string' }, null, '\t')`

![screen shot of jsonfile library](https://user-images.githubusercontent.com/8604754/59275261-99c0ed80-8c79-11e9-8ad5-4dc73560287e.png)

